### PR TITLE
fix(android): fix event emitter warning missing methods

### DIFF
--- a/android/src/main/java/dev/rnap/reactnativeaudiopro/AudioProModule.kt
+++ b/android/src/main/java/dev/rnap/reactnativeaudiopro/AudioProModule.kt
@@ -127,6 +127,11 @@ class AudioProModule(private val reactContext: ReactApplicationContext) :
 		AudioProAmbientController.ambientSeekTo(positionMs.toLong())
 	}
 
+    // Keep: Required for RN built in Event Emitter Calls.
+    @ReactMethod fun addListener(eventName: String) {}
+
+    @ReactMethod fun removeListeners(count: Int) {}
+
 	override fun getName(): String {
 		return NAME
 	}


### PR DESCRIPTION
Hello I am running:
```
    "react-native": "0.79.2",
    "react-native-audio-pro": "^9.9.1",
```

And noticed I was getting these warnings from your library:
```
 WARN  `new NativeEventEmitter()` was called with a non-null argument without the required `addListener` method.
 WARN  `new NativeEventEmitter()` was called with a non-null argument without the required `removeListeners` method.
 WARN  `new NativeEventEmitter()` was called with a non-null argument without the required `addListener` method.
 WARN  `new NativeEventEmitter()` was called with a non-null argument without the required `removeListeners` method.
```

It seems that these method stubs are required to suppress these warnings. 

Another person found the same solution for a different library:
https://blog.projectmw.net/how-to-fix-nativeeventemitter-warning

Thanks for the awesome library btw.

---

I created a patch for this using patch-package for anyone who is bothered by this warning:
https://gist.github.com/istareatscreens/7b625cb7ee4f8459e94a8d7aef8cb45b