### PR TITLE
fix: respect startTimeMs when autoPlay is undefined

### DIFF
--- a/src/audioPro.ts
+++ b/src/audioPro.ts
@@ -113,7 +113,9 @@ export const AudioPro = {
 		}
 
 		// Clear startTimeMs if autoPlay is false
-		options.startTimeMs = options.autoPlay ? options.startTimeMs : undefined;
+		if (options.autoPlay === false) {
+			options.startTimeMs = undefined;
+		}
 
 		// Prepare options for native module
 		const nativeOptions = {


### PR DESCRIPTION
First of all, huge thanks to Brad and every other contributor here for the work on RNAP to date! Here's a tiny PR that fixes a gotcha I ran into the other day, hopefully someone else finds it useful :slightly_smiling_face:

#### Why
The docs state that when calling `AudioPro.play()`, the `autoPlay` option is assumed true if it's undefined, however when starting playback with `startTimeMs` configured, the start time is ignored unless `autoPlay` is explicitly set to true (and _not_ undefined). I'm assuming that this is _probably_ unintended behaviour.

#### What
I've changed the options handling to only reset the `startTimeMs` value if `autoPlay` is explicitly disabled and isn't just undefined. There _might_ be an argument to be made that this is a breaking change for any apps that make assumptions around the current behaviour.