### PR TITLE
fix: honor startTimeMs even when autoplay is disabled

### DIFF
--- a/README.md
+++ b/README.md
@@ -306,7 +306,7 @@ type AudioProSetupOptions = {
 type AudioProPlayOptions = {
     autoPlay?: boolean; // Whether to start playback immediately (default: true)
     headers?: AudioProHeaders; // Custom HTTP headers for audio and artwork requests
-    startTimeMs?: number; // Optional position in milliseconds to start playback from. Ignored if autoPlay is false.
+    startTimeMs?: number; // Optional position in milliseconds to start playback from, even if autoPlay is false.
 };
 ```
 </details>

--- a/android/src/main/java/dev/rnap/reactnativeaudiopro/AudioProController.kt
+++ b/android/src/main/java/dev/rnap/reactnativeaudiopro/AudioProController.kt
@@ -209,10 +209,10 @@ object AudioProController {
 		ensurePreparedForNewPlayback()
 		activeTrack = track
 
-		// If startTimeMs is provided and autoPlay is true, set pendingSeekPosition
-		if (opts.startTimeMs != null && opts.autoPlay) {
-			flowPendingSeekPosition = opts.startTimeMs
-		}
+                // If startTimeMs is provided, set a pending seek position
+                if (opts.startTimeMs != null) {
+                        flowPendingSeekPosition = opts.startTimeMs
+                }
 
 		log(
 			"Configured with " +

--- a/src/audioPro.ts
+++ b/src/audioPro.ts
@@ -141,11 +141,6 @@ export const AudioPro = {
 			setError(null);
 		}
 
-		// Clear startTimeMs if autoPlay is false
-		if (options.autoPlay === false) {
-			options.startTimeMs = undefined;
-		}
-
 		// Prepare options for native module
 		const nativeOptions = {
 			...configureOptions,


### PR DESCRIPTION
## Summary
- preserve `startTimeMs` option in JS API when `autoPlay` is false
- seek to `startTimeMs` on Android regardless of `autoPlay`
- clarify docs that `startTimeMs` is always honored

## Testing
- `yarn lint`
- `yarn typecheck`
- `yarn test` *(fails: Cannot use spyOn on a primitive value; undefined given)*

------
https://chatgpt.com/codex/tasks/task_e_68b79384e234832db6c9595078769e8c