### PR TITLE
refactor: simplify useAudioPro

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,9 @@ React Native Audio Pro also includes a few optional capabilities that support mo
 ```bash
 npm install react-native-audio-pro
 ```
+
 or
+
 ```bash
 yarn add react-native-audio-pro
 ```
@@ -65,6 +67,7 @@ yarn add react-native-audio-pro
 ### 🍎 iOS Installation
 
 Install the CocoaPods dependencies:
+
 ```bash
 npx pod-install
 ```
@@ -105,13 +108,13 @@ buildscript {
 2. **For iOS, enable Background Modes in your `app.json`:**
     ```json
     {
-      "expo": {
-        "ios": {
-          "infoPlist": {
-            "UIBackgroundModes": ["audio"]
-          }
-        }
-      }
+    	"expo": {
+    		"ios": {
+    			"infoPlist": {
+    				"UIBackgroundModes": ["audio"]
+    			}
+    		}
+    	}
     }
     ```
 3. **For Android, update your plugins array in `app.json`:**
@@ -137,27 +140,27 @@ React Native Audio Pro supports various audio file formats including MP3, AAC, a
 
 ### 🛠 Methods
 
-| Method                                                        | Description                                                                                | Return Value                             |
-|---------------------------------------------------------------|--------------------------------------------------------------------------------------------|------------------------------------------|
-| **play(track: AudioProTrack, options?: AudioProPlayOptions)** | Loads and starts playing the specified track.                                              | `void`                                   |
-| **pause()**                                                   | Pauses the current playback.                                                               | `void`                                   |
-| **resume()**                                                  | Resumes playback if paused.                                                                | `void`                                   |
-| **stop()**                                                    | Stops playback and resets position to 0 while keeping the current track loaded; use `clear()` to unload it.                | `void`                                   |
-| **clear()**                                                   | Fully resets the player to IDLE state, tears down the player instance.                     | `void`                                   |
-| **seekTo(positionMs: number)**                                | Seeks to a specific position (in milliseconds).                                            | `void`                                   |
-| **seekForward(amountMs?: number)**                            | Seeks forward by specified milliseconds (default: 30 seconds).                             | `void`                                   |
-| **seekBack(amountMs?: number)**                               | Seeks backward by specified milliseconds (default: 30 seconds).                            | `void`                                   |
-| **configure(options: AudioProSetupOptions)**                  | Optional. Sets playback options. Takes effect the next time `play()` is called.            | `void`                                   |
-| **setProgressInterval(ms: number)**                           | Sets the PROGRESS events frequency (in ms). Takes effect the next time `play()` is called. | `void`                                   |
-| **getProgressInterval()**                                     | Returns the current progress interval in milliseconds.                                     | `number`                                 |
-| **getTimings()**                                              | Returns the current playback position and total duration in milliseconds.                  | `{ position: number, duration: number }` |
-| **getState()**                                                | Returns the current playback state.                                                        | `AudioProState`                          |
-| **getPlayingTrack()**                                         | Returns the current track, or `null` if none is loaded.                       | `AudioProTrack \| null`                  |
-| **setPlaybackSpeed(speed: number)**                           | Sets the playback speed rate (0.25 to 2.0). Normal speed is 1.0.                           | `void`                                   |
-| **getPlaybackSpeed()**                                        | Returns the current playback speed rate.                                                   | `number`                                 |
-| **setVolume(volume: number)**                                 | Sets the playback volume from (0.0 to 1.0). Does not affect the system volume.             | `void`                                   |
-| **getVolume()**                                               | Returns the current relative volume (0.0 to 1.0).                                          | `number`                                 |
-| **getError()**                                                | Returns the last error that occurred, or null if no error has occurred.                    | `AudioProPlaybackErrorPayload \| null`   |                                                                                   | `EmitterSubscription` |
+| Method                                                        | Description                                                                                                 | Return Value                             |
+| ------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------- | ---------------------------------------- | --- | --------------------- |
+| **play(track: AudioProTrack, options?: AudioProPlayOptions)** | Loads and starts playing the specified track.                                                               | `void`                                   |
+| **pause()**                                                   | Pauses the current playback.                                                                                | `void`                                   |
+| **resume()**                                                  | Resumes playback if paused.                                                                                 | `void`                                   |
+| **stop()**                                                    | Stops playback and resets position to 0 while keeping the current track loaded; use `clear()` to unload it. | `void`                                   |
+| **clear()**                                                   | Fully resets the player to IDLE state, tears down the player instance.                                      | `void`                                   |
+| **seekTo(positionMs: number)**                                | Seeks to a specific position (in milliseconds).                                                             | `void`                                   |
+| **seekForward(amountMs?: number)**                            | Seeks forward by specified milliseconds (default: 30 seconds).                                              | `void`                                   |
+| **seekBack(amountMs?: number)**                               | Seeks backward by specified milliseconds (default: 30 seconds).                                             | `void`                                   |
+| **configure(options: AudioProSetupOptions)**                  | Optional. Sets playback options. Takes effect the next time `play()` is called.                             | `void`                                   |
+| **setProgressInterval(ms: number)**                           | Sets the PROGRESS events frequency (in ms). Takes effect the next time `play()` is called.                  | `void`                                   |
+| **getProgressInterval()**                                     | Returns the current progress interval in milliseconds.                                                      | `number`                                 |
+| **getTimings()**                                              | Returns the current playback position and total duration in milliseconds.                                   | `{ position: number, duration: number }` |
+| **getState()**                                                | Returns the current playback state.                                                                         | `AudioProState`                          |
+| **getPlayingTrack()**                                         | Returns the current track, or `null` if none is loaded.                                                     | `AudioProTrack \| null`                  |
+| **setPlaybackSpeed(speed: number)**                           | Sets the playback speed rate (0.25 to 2.0). Normal speed is 1.0.                                            | `void`                                   |
+| **getPlaybackSpeed()**                                        | Returns the current playback speed rate.                                                                    | `number`                                 |
+| **setVolume(volume: number)**                                 | Sets the playback volume from (0.0 to 1.0). Does not affect the system volume.                              | `void`                                   |
+| **getVolume()**                                               | Returns the current relative volume (0.0 to 1.0).                                                           | `number`                                 |
+| **getError()**                                                | Returns the last error that occurred, or null if no error has occurred.                                     | `AudioProPlaybackErrorPayload \| null`   |     | `EmitterSubscription` |
 
 ### ⚡️ React Hook
 
@@ -167,8 +170,15 @@ The `useAudioPro` hook provides real-time access to the audio player state withi
 const { state, position, duration, playingTrack, playbackSpeed, volume, error } = useAudioPro();
 ```
 
+To subscribe to only the specific piece of state your component needs (and avoid unnecessary re-renders), you can pass a selector function:
+
+```typescript jsx
+// Only re-renders when the playing track changes
+const playingTrack = useAudioPro((s) => s.playingTrack);
+```
+
 | Value             | Description                                                    | Type                                   |
-|-------------------|----------------------------------------------------------------|----------------------------------------|
+| ----------------- | -------------------------------------------------------------- | -------------------------------------- |
 | **state**         | Current playback state of the audio player.                    | `AudioProState`                        |
 | **position**      | Current playback position in milliseconds.                     | `number`                               |
 | **duration**      | Total duration of the current track in milliseconds.           | `number`                               |
@@ -180,7 +190,7 @@ const { state, position, duration, playingTrack, playbackSpeed, volume, error } 
 ### 🎧 Event Listeners
 
 | Method                                                | Description                                                                       | Return Value                                                                    |
-|-------------------------------------------------------|-----------------------------------------------------------------------------------|---------------------------------------------------------------------------------|
+| ----------------------------------------------------- | --------------------------------------------------------------------------------- | ------------------------------------------------------------------------------- |
 | **addEventListener(callback: AudioProEventCallback)** | Listens for playback events (e.g., state changes, track ended, errors, progress). | `EmitterSubscription` - A subscription that can be used to remove the listener. |
 
 ### 🧱 Enums
@@ -188,7 +198,7 @@ const { state, position, duration, playingTrack, playbackSpeed, volume, error } 
 #### AudioProState
 
 | State     | Description                                                                                                          |
-|-----------|----------------------------------------------------------------------------------------------------------------------|
+| --------- | -------------------------------------------------------------------------------------------------------------------- |
 | `IDLE`    | The default state on app launch. Represents a player with no loaded track and fully cleared media sessions.          |
 | `STOPPED` | Playback is stopped but the track remains loaded. Position is reset to 0, and media session controls remain visible. |
 | `LOADING` | A track is being loaded or buffered and is not yet ready for playback.                                               |
@@ -198,28 +208,28 @@ const { state, position, duration, playingTrack, playbackSpeed, volume, error } 
 
 #### AudioProEventType
 
-| Event                    | Description                                                                               |
-|--------------------------|-------------------------------------------------------------------------------------------|
-| `STATE_CHANGED`          | Emitted when the player's state changes (e.g., from LOADING to PLAYING).                  |
-| `PROGRESS`               | Emitted approximately once per second during playback with current position and duration. |
-| `TRACK_ENDED`            | Emitted when a track completes playback naturally.                                        |
+| Event                    | Description                                                                                   |
+| ------------------------ | --------------------------------------------------------------------------------------------- |
+| `STATE_CHANGED`          | Emitted when the player's state changes (e.g., from LOADING to PLAYING).                      |
+| `PROGRESS`               | Emitted approximately once per second during playback with current position and duration.     |
+| `TRACK_ENDED`            | Emitted when a track completes playback naturally.                                            |
 | `SEEK_COMPLETE`          | Emitted when a seek operation completes. Payload includes `triggeredBy` (`USER` or `SYSTEM`). |
-| `PLAYBACK_SPEED_CHANGED` | Emitted when the playback speed is changed.                                               |
-| `REMOTE_NEXT`            | Emitted when the user presses the "Next" button on lock screen controls.                  |
-| `REMOTE_PREV`            | Emitted when the user presses the "Previous" button on lock screen controls.              |
-| `PLAYBACK_ERROR`         | Emitted when a playback error occurs.                                                     |
+| `PLAYBACK_SPEED_CHANGED` | Emitted when the playback speed is changed.                                                   |
+| `REMOTE_NEXT`            | Emitted when the user presses the "Next" button on lock screen controls.                      |
+| `REMOTE_PREV`            | Emitted when the user presses the "Previous" button on lock screen controls.                  |
+| `PLAYBACK_ERROR`         | Emitted when a playback error occurs.                                                         |
 
 #### AudioProAmbientEventType
 
 | Event                 | Description                                                                                 |
-|-----------------------|---------------------------------------------------------------------------------------------|
+| --------------------- | ------------------------------------------------------------------------------------------- |
 | `AMBIENT_TRACK_ENDED` | Emitted when an ambient track completes playback naturally (when `loop` is set to `false`). |
 | `AMBIENT_ERROR`       | Emitted when an error occurs during ambient audio playback.                                 |
 
 #### AudioProContentType
 
 | Type     | Description                                                                                    |
-|----------|------------------------------------------------------------------------------------------------|
+| -------- | ---------------------------------------------------------------------------------------------- |
 | `MUSIC`  | Optimized for music playback. Use for songs or music-heavy audio content. This is the default. |
 | `SPEECH` | Optimized for spoken word content. Use for podcasts, audiobooks, or speech-heavy content.      |
 
@@ -231,10 +241,10 @@ Both iOS and Android support lock screen and notification controls for play/paus
 
 ```typescript
 AudioPro.configure({
-  contentType: AudioProContentType.MUSIC,
-  showNextPrevControls: true, // Hide next/previous buttons
-  showSkipControls: false,      // Show skip/seek forward/back buttons (default: true)
-  skipIntervalMs: 30000,            // Number of milliseconds for skip forward/back controls (default: 30000)
+	contentType: AudioProContentType.MUSIC,
+	showNextPrevControls: true, // Hide next/previous buttons
+	showSkipControls: false, // Show skip/seek forward/back buttons (default: true)
+	skipIntervalMs: 30000, // Number of milliseconds for skip forward/back controls (default: 30000)
 });
 ```
 
@@ -253,10 +263,10 @@ AudioPro.configure({
 
 ```typescript
 AudioPro.configure({
-  contentType: AudioProContentType.SPEECH,
-  showNextPrevControls: false,
-  showSkipControls: true,      // Only show skip/seek buttons
-  skipIntervalMs: 15000,       // 15 second skip
+	contentType: AudioProContentType.SPEECH,
+	showNextPrevControls: false,
+	showSkipControls: true, // Only show skip/seek buttons
+	skipIntervalMs: 15000, // 15 second skip
 });
 ```
 
@@ -268,15 +278,15 @@ Android supports both options but will prioritize Next/Prev if both are enabled.
 
 > 🧠 Ambient playback is designed to be stateless, simple, and minimal for background sounds, ambient loops, or lightweight audio tasks.
 
-| Method                                                         | Description                                                                                                                                           | Return Value          |
-|----------------------------------------------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------|-----------------------|
-| **ambientPlay(options: AmbientAudioPlayOptions)**              | Plays a lightweight ambient audio track, isolated from the main player. Accepts a remote or local `url` and optional `loop` flag (default: `true`).   | `void`                |
-| **ambientStop()**                                              | Stops the ambient audio playback.                                                                                                                     | `void`                |
-| **ambientPause()**                                             | Pause ambient audio playback (no-op if already paused or not playing).                                                                                | `void`                |
-| **ambientResume()**                                            | Resume ambient audio playback if paused (no-op if already playing or no active track).                                                                | `void`                |
-| **ambientSeekTo(positionMs: number)**                          | Seek to the specified position (in milliseconds) in the ambient track (if supported). Silently ignore if not supported or if no active ambient track. | `void`                |
-| **ambientSetVolume(volume: number)**                           | Sets the volume of ambient audio playback from 0.0 (mute) to 1.0 (full output).                                                                       | `void`                |
-| **addAmbientListener(callback: AudioProAmbientEventCallback)** | Listens for ambient audio events (e.g., track ended, errors).
+| Method                                                         | Description                                                                                                                                           | Return Value |
+| -------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------- | ------------ |
+| **ambientPlay(options: AmbientAudioPlayOptions)**              | Plays a lightweight ambient audio track, isolated from the main player. Accepts a remote or local `url` and optional `loop` flag (default: `true`).   | `void`       |
+| **ambientStop()**                                              | Stops the ambient audio playback.                                                                                                                     | `void`       |
+| **ambientPause()**                                             | Pause ambient audio playback (no-op if already paused or not playing).                                                                                | `void`       |
+| **ambientResume()**                                            | Resume ambient audio playback if paused (no-op if already playing or no active track).                                                                | `void`       |
+| **ambientSeekTo(positionMs: number)**                          | Seek to the specified position (in milliseconds) in the ambient track (if supported). Silently ignore if not supported or if no active ambient track. | `void`       |
+| **ambientSetVolume(volume: number)**                           | Sets the volume of ambient audio playback from 0.0 (mute) to 1.0 (full output).                                                                       | `void`       |
+| **addAmbientListener(callback: AudioProAmbientEventCallback)** | Listens for ambient audio events (e.g., track ended, errors).                                                                                         |
 
 ### 🧩 Types
 
@@ -285,30 +295,31 @@ Android supports both options but will prioritize Next/Prev if both are enabled.
 
 ```typescript
 type AudioProTrack = {
-    id: string;
-    url: string; // the media url (mp3, m4a) - https://, or file://
-    title: string;
-    artwork: string; // the image url (jpg, png) - https://, or file://
-    album?: string;
-    artist?: string;
+	id: string;
+	url: string; // the media url (mp3, m4a) - https://, or file://
+	title: string;
+	artwork: string; // the image url (jpg, png) - https://, or file://
+	album?: string;
+	artist?: string;
 };
 
 type AudioProSetupOptions = {
-    contentType?: AudioProContentType; // MUSIC or SPEECH
-    debug?: boolean;                   // Verbose logging
-    debugIncludesProgress?: boolean;   // Include PROGRESS events in debug logs (default: false)
-    progressIntervalMs?: number;       // Frequency (in ms) for PROGRESS events (default: 1000ms)
-    showNextPrevControls?: boolean;    // Show next/previous buttons (default: true)
-    showSkipControls?: boolean;        // Show skip/seek forward/back buttons (default: true)
-    skipIntervalMs?: number;           // Interval in milliseconds for skip forward/back controls (default: 30000)
+	contentType?: AudioProContentType; // MUSIC or SPEECH
+	debug?: boolean; // Verbose logging
+	debugIncludesProgress?: boolean; // Include PROGRESS events in debug logs (default: false)
+	progressIntervalMs?: number; // Frequency (in ms) for PROGRESS events (default: 1000ms)
+	showNextPrevControls?: boolean; // Show next/previous buttons (default: true)
+	showSkipControls?: boolean; // Show skip/seek forward/back buttons (default: true)
+	skipIntervalMs?: number; // Interval in milliseconds for skip forward/back controls (default: 30000)
 };
 
 type AudioProPlayOptions = {
-    autoPlay?: boolean; // Whether to start playback immediately (default: true)
-    headers?: AudioProHeaders; // Custom HTTP headers for audio and artwork requests
-    startTimeMs?: number; // Optional position in milliseconds to start playback from, even if autoPlay is false.
+	autoPlay?: boolean; // Whether to start playback immediately (default: true)
+	headers?: AudioProHeaders; // Custom HTTP headers for audio and artwork requests
+	startTimeMs?: number; // Optional position in milliseconds to start playback from, even if autoPlay is false.
 };
 ```
+
 </details>
 
 <details>
@@ -317,61 +328,63 @@ type AudioProPlayOptions = {
 ```typescript
 // Unified event structure
 interface AudioProEvent {
-    type: AudioProEventType;
-    track: AudioProTrack | null; // Required for all events except REMOTE_NEXT and REMOTE_PREV
-    payload?: {
-        state?: AudioProState;
-        position?: number;
-        duration?: number;
-        error?: string;
-        errorCode?: number;
-        speed?: number;
-    };
+	type: AudioProEventType;
+	track: AudioProTrack | null; // Required for all events except REMOTE_NEXT and REMOTE_PREV
+	payload?: {
+		state?: AudioProState;
+		position?: number;
+		duration?: number;
+		error?: string;
+		errorCode?: number;
+		speed?: number;
+	};
 }
 
 // Note: Command events (REMOTE_NEXT, REMOTE_PREV) don't update state and don't require track information.
 
 // Event payload examples
 interface AudioProStateChangedPayload {
-    state: AudioProState;
-    position: number;
-    duration: number;
+	state: AudioProState;
+	position: number;
+	duration: number;
 }
 
 interface AudioProTrackEndedPayload {
-    position: number;
-    duration: number;
+	position: number;
+	duration: number;
 }
 
 interface AudioProPlaybackErrorPayload {
-    error: string;
-    errorCode?: number;
+	error: string;
+	errorCode?: number;
 }
 
 interface AudioProPlaybackSpeedChangedPayload {
-    speed: number;
+	speed: number;
 }
 
 // Ambient audio event structure
 interface AudioProAmbientEvent {
-    type: AudioProAmbientEventType;
-    payload?: {
-        error?: string;
-    };
+	type: AudioProAmbientEventType;
+	payload?: {
+		error?: string;
+	};
 }
 
 // Ambient audio play options
 interface AmbientAudioPlayOptions {
-    url: string;
-    loop?: boolean;
+	url: string;
+	loop?: boolean;
 }
 ```
+
 </details>
 
 <details>
 <summary><b>About contentType</b></summary>
 
 Use `AudioProContentType.SPEECH` for podcasts or audiobooks, `AudioProContentType.MUSIC` for songs or music-heavy audio. This optimizes playback behavior like audio focus and routing. Defaults to `AudioProContentType.MUSIC`.
+
 </details>
 
 <details>
@@ -379,7 +392,7 @@ Use `AudioProContentType.SPEECH` for podcasts or audiobooks, `AudioProContentTyp
 
 - `debug`: When set to `true`, enables verbose logging of all audio events. Useful for development and troubleshooting.
 - `debugIncludesProgress`: When set to `true`, includes PROGRESS events in debug logs. PROGRESS events occur every second during playback and can flood the logs, making it harder to see other important events. Defaults to `false`.
-</details>
+    </details>
 
 <details>
 <summary><b>About progressIntervalMs</b></summary>
@@ -390,7 +403,7 @@ Use `AudioProContentType.SPEECH` for podcasts or audiobooks, `AudioProContentTyp
 - Can be set via `configure()` or `setProgressInterval()`
 - Changes take effect on the next call to `play()`
 - Useful for making the UI more responsive for short or high-precision audio playback
-</details>
+    </details>
 
 ### Handling Remote Events
 
@@ -401,24 +414,24 @@ import { AudioPro, AudioProEventType } from 'react-native-audio-pro';
 
 // Set up listeners outside React components (see warning section below)
 const subscription = AudioPro.addEventListener((event) => {
-  switch (event.type) {
-    case AudioProEventType.REMOTE_NEXT:
-      // Handle next track button press
-      console.log('User pressed Next button');
-      // Load and play next track
-      break;
+	switch (event.type) {
+		case AudioProEventType.REMOTE_NEXT:
+			// Handle next track button press
+			console.log('User pressed Next button');
+			// Load and play next track
+			break;
 
-    case AudioProEventType.REMOTE_PREV:
-      // Handle previous track button press
-      console.log('User pressed Previous button');
-      // Load and play previous track
-      break;
+		case AudioProEventType.REMOTE_PREV:
+			// Handle previous track button press
+			console.log('User pressed Previous button');
+			// Load and play previous track
+			break;
 
-    case AudioProEventType.STATE_CHANGED:
-      // Handle state changes
-      console.log('State changed to:', event.payload?.state);
-      break;
-  }
+		case AudioProEventType.STATE_CHANGED:
+			// Handle state changes
+			console.log('State changed to:', event.payload?.state);
+			break;
+	}
 });
 
 // Later, when you want to remove the listener
@@ -469,16 +482,16 @@ import { AudioPro, AudioProContentType } from 'react-native-audio-pro';
 
 // Optional: Set playback config
 AudioPro.configure({
-  contentType: AudioProContentType.MUSIC,
-  debug: __DEV__,
+	contentType: AudioProContentType.MUSIC,
+	debug: __DEV__,
 });
 
 const track = {
-  id: 'track-001',
-  url: 'https://example.com/audio.mp3',
-  title: 'My Track',
-  artwork: 'https://example.com/artwork.jpg',
-  artist: 'Artist Name',
+	id: 'track-001',
+	url: 'https://example.com/audio.mp3',
+	title: 'My Track',
+	artwork: 'https://example.com/artwork.jpg',
+	artist: 'Artist Name',
 };
 
 // Load and play the track
@@ -507,7 +520,9 @@ const playingTrack = AudioPro.getPlayingTrack();
 const speed = AudioPro.getPlaybackSpeed();
 const volume = AudioPro.getVolume();
 const error = AudioPro.getError();
-console.log(`Currently playing: ${playingTrack?.title} (${position}/${duration}ms) - State: ${state} - Speed: ${speed}x - Volume: ${Math.round(volume * 100)}%`);
+console.log(
+	`Currently playing: ${playingTrack?.title} (${position}/${duration}ms) - State: ${state} - Speed: ${speed}x - Volume: ${Math.round(volume * 100)}%`,
+);
 ```
 
 ## 🔊 Ambient Audio
@@ -523,27 +538,27 @@ import { AudioPro } from 'react-native-audio-pro';
 
 // Play ambient audio
 AudioPro.ambientPlay({
-  url: 'https://example.com/ambient.mp3',
-  loop: true, // Optional, defaults to true
+	url: 'https://example.com/ambient.mp3',
+	loop: true, // Optional, defaults to true
 });
 
-AudioPro.ambientPause();    // Pause ambient playback
-AudioPro.ambientResume();   // Resume ambient playback
-AudioPro.ambientStop();     // Stop and clean up ambient playback
+AudioPro.ambientPause(); // Pause ambient playback
+AudioPro.ambientResume(); // Resume ambient playback
+AudioPro.ambientStop(); // Stop and clean up ambient playback
 AudioPro.ambientSeekTo(30000); // Seek to 30 seconds
 
 AudioPro.ambientSetVolume(0.5); // 50% volume
 
 // Listen for ambient audio events
 const subscription = AudioPro.addAmbientListener((event) => {
-  switch (event.type) {
-    case 'AMBIENT_TRACK_ENDED':
-      console.log('Ambient track ended');
-      break;
-    case 'AMBIENT_ERROR':
-      console.error('Ambient error:', event.payload?.error);
-      break;
-  }
+	switch (event.type) {
+		case 'AMBIENT_TRACK_ENDED':
+			console.log('Ambient track ended');
+			break;
+		case 'AMBIENT_ERROR':
+			console.error('Ambient error:', event.payload?.error);
+			break;
+	}
 });
 
 // Later, remove the listener
@@ -587,36 +602,38 @@ setupAudio();
 import { AudioPro, AudioProEventType, AudioProContentType } from 'react-native-audio-pro';
 
 export function setupAudio() {
-  // Configure audio settings
-  AudioPro.configure({
-    contentType: AudioProContentType.MUSIC,
-    debug: __DEV__,
-    debugIncludesProgress: false,
-    progressIntervalMs: 1000,
-    showNextPrevControls: true, // Show next/previous buttons on lock screen (default)
-  });
+	// Configure audio settings
+	AudioPro.configure({
+		contentType: AudioProContentType.MUSIC,
+		debug: __DEV__,
+		debugIncludesProgress: false,
+		progressIntervalMs: 1000,
+		showNextPrevControls: true, // Show next/previous buttons on lock screen (default)
+	});
 
-  // Set up event listeners that persist for the app's lifetime
-  AudioPro.addEventListener((event) => {
-    switch (event.type) {
-      case AudioProEventType.TRACK_ENDED:
-        // Auto-play next track when current track ends
-        const nextTrack = determineNextTrack();
-        if (nextTrack) {
-          AudioPro.play(nextTrack);
-        }
-        break;
+	// Set up event listeners that persist for the app's lifetime
+	AudioPro.addEventListener((event) => {
+		switch (event.type) {
+			case AudioProEventType.TRACK_ENDED:
+				// Auto-play next track when current track ends
+				const nextTrack = determineNextTrack();
+				if (nextTrack) {
+					AudioPro.play(nextTrack);
+				}
+				break;
 
-      case AudioProEventType.REMOTE_NEXT:
-        // Handle next button press from lock screen/notification
-        const nextTrackFromRemote = determineNextTrack();
-        AudioPro.play(nextTrackFromRemote);
-        break;
-    }
-  });
+			case AudioProEventType.REMOTE_NEXT:
+				// Handle next button press from lock screen/notification
+				const nextTrackFromRemote = determineNextTrack();
+				AudioPro.play(nextTrackFromRemote);
+				break;
+		}
+	});
 }
 
-function determineNextTrack() { /* Your logic here */ }
+function determineNextTrack() {
+	/* Your logic here */
+}
 ```
 
 ## 📱 Example App
@@ -632,12 +649,13 @@ It demonstrates how to use `react-native-audio-pro` in a real React Native app, 
 
 ### To run the example:
 
-* Clone this repo and run the below commands
+- Clone this repo and run the below commands
 
 ```bash
 yarn install
 yarn example start
 ```
+
 And in a new terminal window/pane:
 
 ```bash

--- a/docs/index.html
+++ b/docs/index.html
@@ -1,107 +1,137 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en" data-theme="dark">
-<head>
-  <meta charset="UTF-8" />
-  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>React Native Audio Pro</title>
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@picocss/pico@2/css/pico.min.css" />
-  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/themes/prism-tomorrow.min.css" />
-  <style>
-    :root {
-      --spacing: 1rem;
-      --border-color: #444;
-    }
+	<head>
+		<meta charset="UTF-8" />
+		<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+		<title>React Native Audio Pro</title>
+		<link
+			rel="stylesheet"
+			href="https://cdn.jsdelivr.net/npm/@picocss/pico@2/css/pico.min.css"
+		/>
+		<link
+			rel="stylesheet"
+			href="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/themes/prism-tomorrow.min.css"
+		/>
+		<style>
+			:root {
+				--spacing: 1rem;
+				--border-color: #444;
+			}
 
-    body {
-      padding: var(--spacing);
-      font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Open Sans', 'Helvetica Neue', sans-serif;
-      font-size: 16px;
-    }
+			body {
+				padding: var(--spacing);
+				font-family:
+					-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu,
+					Cantarell, 'Open Sans', 'Helvetica Neue', sans-serif;
+				font-size: 16px;
+			}
 
-    header, footer, main {
-      max-width: 700px;
-      margin: 0 auto;
-    }
+			header,
+			footer,
+			main {
+				max-width: 700px;
+				margin: 0 auto;
+			}
 
-    header, footer {
-      text-align: center;
-      padding: calc(var(--spacing) * 2);
-    }
+			header,
+			footer {
+				text-align: center;
+				padding: calc(var(--spacing) * 2);
+			}
 
-    header {
-      border-bottom: 1px solid var(--border-color);
-    }
+			header {
+				border-bottom: 1px solid var(--border-color);
+			}
 
-    main {
-      /*margin: var(--spacing) auto;*/
-    }
+			main {
+				/*margin: var(--spacing) auto;*/
+			}
 
-    h1 {
-      margin-bottom: 0.5rem;
-    }
+			h1 {
+				margin-bottom: 0.5rem;
+			}
 
-    section {
-      margin-bottom: calc(var(--spacing) * 2);
-    }
+			section {
+				margin-bottom: calc(var(--spacing) * 2);
+			}
 
-    .badge-container {
-      display: inline-flex;
-      gap: 0.5rem;
-      margin-top: 0.5rem;
-    }
+			.badge-container {
+				display: inline-flex;
+				gap: 0.5rem;
+				margin-top: 0.5rem;
+			}
 
-    pre {
-      background: #2d2d2d;
-      color: #ccc;
-      padding: var(--spacing);
-      border-radius: 8px;
-      overflow-x: auto;
-    }
-  </style>
-</head>
-<body>
-<header>
-  <h1>React Native Audio Pro</h1>
-  <p>A React Native module for robust audio playback from remote audio files and local files. Ideal for music, audiobook, and podcast apps. Works on iOS and Android.</p>
-  <div class="badge-container">
-    <a href="https://www.npmjs.com/package/react-native-audio-pro">
-      <img src="https://img.shields.io/npm/v/react-native-audio-pro?logo=npm&logoColor=white&labelColor=grey&color=blue" alt="npm version" />
-    </a>
-    <a href="https://rnap.dev">
-      <img src="https://img.shields.io/badge/website-rnap.dev-grey?logo=google-chrome&logoColor=white&color=blue" alt="Website" />
-    </a>
-    <a href="https://github.com/evergrace-co/react-native-audio-pro" target="_blank" rel="noopener">
-      <img src="https://img.shields.io/badge/evergrace--co-react--native--audio--pro-grey?logo=github&logoColor=white&labelColor=grey&color=blue" alt="GitHub Repo" />
-    </a>
-  </div>
-</header>
+			pre {
+				background: #2d2d2d;
+				color: #ccc;
+				padding: var(--spacing);
+				border-radius: 8px;
+				overflow-x: auto;
+			}
+		</style>
+	</head>
+	<body>
+		<header>
+			<h1>React Native Audio Pro</h1>
+			<p>
+				A React Native module for robust audio playback from remote audio files and local
+				files. Ideal for music, audiobook, and podcast apps. Works on iOS and Android.
+			</p>
+			<div class="badge-container">
+				<a href="https://www.npmjs.com/package/react-native-audio-pro">
+					<img
+						src="https://img.shields.io/npm/v/react-native-audio-pro?logo=npm&logoColor=white&labelColor=grey&color=blue"
+						alt="npm version"
+					/>
+				</a>
+				<a href="https://rnap.dev">
+					<img
+						src="https://img.shields.io/badge/website-rnap.dev-grey?logo=google-chrome&logoColor=white&color=blue"
+						alt="Website"
+					/>
+				</a>
+				<a
+					href="https://github.com/evergrace-co/react-native-audio-pro"
+					target="_blank"
+					rel="noopener"
+				>
+					<img
+						src="https://img.shields.io/badge/evergrace--co-react--native--audio--pro-grey?logo=github&logoColor=white&labelColor=grey&color=blue"
+						alt="GitHub Repo"
+					/>
+				</a>
+			</div>
+		</header>
 
-<main>
-  <section id="features">
-    <h2>🚀 Features</h2>
-	  <ul>
-		  <li>🎵 Powered by Media3 (Android) & AVFoundation (iOS)</li>
-		  <li>🔒 Lock screen controls & background playback</li>
-		  <li>🔔 Automatic handling of notification center (Android & iOS)</li>
-		  <li>📡 Comprehensive media support:
-			  <ul style="margin-bottom: 0;">
-				  <li>Remote audio files</li>
-				  <li>Local files (audio and artwork)</li>
-			  </ul>
-		  </li>
-		  <li>🔊 Isolated ambient audio system for background sounds</li>
-		  <li>📦 Built fully in TypeScript – no JS wrappers</li>
-		  <li>🧠 Simple React hook & module interface</li>
-		  <li>⚡️ Lightweight, fast, and production-ready</li>
-	  </ul>
-  </section>
+		<main>
+			<section id="features">
+				<h2>🚀 Features</h2>
+				<ul>
+					<li>🎵 Powered by Media3 (Android) & AVFoundation (iOS)</li>
+					<li>🔒 Lock screen controls & background playback</li>
+					<li>🔔 Automatic handling of notification center (Android & iOS)</li>
+					<li>
+						📡 Comprehensive media support:
+						<ul style="margin-bottom: 0">
+							<li>Remote audio files</li>
+							<li>Local files (audio and artwork)</li>
+						</ul>
+					</li>
+					<li>🔊 Isolated ambient audio system for background sounds</li>
+					<li>📦 Built fully in TypeScript – no JS wrappers</li>
+					<li>🧠 Simple React hook & module interface</li>
+					<li>⚡️ Lightweight, fast, and production-ready</li>
+				</ul>
+			</section>
 
-  <section id="hook-example">
-    <h2>🎧 React Hook in Action</h2>
-    <pre><code class="language-ts">import { useAudioPro } from 'react-native-audio-pro';
+			<section id="hook-example">
+				<h2>🎧 React Hook in Action</h2>
+				<pre><code class="language-ts">import { useAudioPro } from 'react-native-audio-pro';
 
 export default function Player() {
   const { state, duration, position, ...etc } = useAudioPro();
+  // Subscribe to a single value to avoid unnecessary re-renders
+  // const playingTrack = useAudioPro((s) => s.playingTrack);
   return (
     &lt;View&gt;
       &lt;Text&gt;State: {state}&lt;/Text&gt;
@@ -110,11 +140,11 @@ export default function Player() {
   );
 }
 </code></pre>
-  </section>
+			</section>
 
-  <section id="api-example">
-    <h2>🧩 Module in Action</h2>
-    <pre><code class="language-ts">import {AudioPro} from 'react-native-audio-pro';
+			<section id="api-example">
+				<h2>🧩 Module in Action</h2>
+				<pre><code class="language-ts">import {AudioPro} from 'react-native-audio-pro';
 
 AudioPro.configure({ contentType: 'speech' });
 
@@ -135,11 +165,14 @@ AudioPro.play(track, {
   }
 });
 </code></pre>
-  </section>
-  <section id="ambient-audio">
-    <h2>🔊 Ambient Audio</h2>
-    <p>Aan isolated ambient audio system for playing background sounds independently from the main player.</p>
-    <pre><code class="language-ts">import { AudioPro } from 'react-native-audio-pro';
+			</section>
+			<section id="ambient-audio">
+				<h2>🔊 Ambient Audio</h2>
+				<p>
+					Aan isolated ambient audio system for playing background sounds independently
+					from the main player.
+				</p>
+				<pre><code class="language-ts">import { AudioPro } from 'react-native-audio-pro';
 
 AudioPro.ambientPlay({
   url: 'https://example.com/nature-sounds.mp3',
@@ -150,34 +183,49 @@ AudioPro.ambientStop();
 
 AudioPro.ambientSetVolume(0.5);
 </code></pre>
-  </section>
+			</section>
 
-  <section id="api-reference">
-    <h2>Documentation</h2>
-    <p>For full setup and API reference, see the <a href="https://github.com/evergrace-co/react-native-audio-pro" target="_blank">GitHub README</a>.</p>
-    <ul>
-      <li>📖 Full API for <code>AudioPro</code> module and <code>useAudioPro</code> hook</li>
-      <li>📦 Details on payloads, types, and setup options</li>
-      <li>🧪 Example app demonstrating integration and usage</li>
-      <li>🔧 Platform-specific setup (Android & iOS)</li>
-    </ul>
-  </section>
-<section id="signoff">
-  <h2>🚀 Ready to build?</h2>
-  <p>Check it out and let us know how you go! If you run into any issues, <a href="https://github.com/evergrace-co/react-native-audio-pro/issues" target="_blank">log an issue</a> — we’ll squash bugs fast. 💪</p>
-</section>
-</main>
+			<section id="api-reference">
+				<h2>Documentation</h2>
+				<p>
+					For full setup and API reference, see the
+					<a href="https://github.com/evergrace-co/react-native-audio-pro" target="_blank"
+						>GitHub README</a
+					>.
+				</p>
+				<ul>
+					<li>
+						📖 Full API for <code>AudioPro</code> module and
+						<code>useAudioPro</code> hook
+					</li>
+					<li>📦 Details on payloads, types, and setup options</li>
+					<li>🧪 Example app demonstrating integration and usage</li>
+					<li>🔧 Platform-specific setup (Android & iOS)</li>
+				</ul>
+			</section>
+			<section id="signoff">
+				<h2>🚀 Ready to build?</h2>
+				<p>
+					Check it out and let us know how you go! If you run into any issues,
+					<a
+						href="https://github.com/evergrace-co/react-native-audio-pro/issues"
+						target="_blank"
+						>log an issue</a
+					>
+					— we’ll squash bugs fast. 💪
+				</p>
+			</section>
+		</main>
 
+		<footer>
+			<small>
+				<a href="https://www.npmjs.com/package/react-native-audio-pro">npm</a> •
+				<a href="https://rnap.dev">rnap.dev</a> •
+				<a href="https://github.com/evergrace-co/react-native-audio-pro">github</a>
+			</small>
+		</footer>
 
-<footer>
-  <small>
-    <a href="https://www.npmjs.com/package/react-native-audio-pro">npm</a> •
-    <a href="https://rnap.dev">rnap.dev</a> •
-    <a href="https://github.com/evergrace-co/react-native-audio-pro">github</a>
-  </small>
-</footer>
-
-<script src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/prism.min.js"></script>
-<script src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/components/prism-typescript.min.js"></script>
-</body>
+		<script src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/prism.min.js"></script>
+		<script src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/components/prism-typescript.min.js"></script>
+	</body>
 </html>

--- a/jest.setup.js
+++ b/jest.setup.js
@@ -54,14 +54,16 @@ const mockActions = {
 	updateFromEvent: jest.fn(),
 };
 
-jest.mock('./src/internalStore', () => ({
-	useInternalStore: {
-		getState: () => ({
-			...mockState,
-			...mockActions,
-		}),
-	},
-}));
+jest.mock('./src/internalStore', () => {
+	const internalStore = jest.fn((selector) => selector(mockState));
+	internalStore.getState = () => ({
+		...mockState,
+		...mockActions,
+	});
+	internalStore.setState = jest.fn();
+	internalStore.subscribe = jest.fn();
+	return { internalStore };
+});
 
 jest.mock('./src/emitter', () => ({
 	emitter: {

--- a/src/__tests__/global.d.ts
+++ b/src/__tests__/global.d.ts
@@ -9,3 +9,5 @@ declare global {
 
 // This file needs to be a module
 export {};
+
+declare module 'react-test-renderer';

--- a/src/__tests__/useAudioPro.selector.test.tsx
+++ b/src/__tests__/useAudioPro.selector.test.tsx
@@ -1,0 +1,56 @@
+/* eslint-disable @typescript-eslint/ban-ts-comment */
+// @ts-nocheck
+import renderer, { act } from 'react-test-renderer';
+
+jest.mock('../internalStore', () => jest.requireActual('../internalStore'));
+
+import { internalStore } from '../internalStore';
+import { useAudioPro } from '../useAudioPro';
+
+describe('useAudioPro selector', () => {
+	afterEach(() => {
+		act(() => {
+			internalStore.setState({ position: 0, trackPlaying: null });
+		});
+	});
+
+	it('does not re-render when unrelated state changes', () => {
+		let renderCount = 0;
+		const Test = () => {
+			renderCount++;
+			// Only subscribe to the playing track
+			useAudioPro((s) => s.trackPlaying);
+			return null;
+		};
+
+		let testRenderer: renderer.ReactTestRenderer;
+		act(() => {
+			testRenderer = renderer.create(<Test />);
+		});
+
+		expect(renderCount).toBe(1);
+
+		act(() => {
+			internalStore.setState({ position: 1000 });
+		});
+		// position change should not trigger re-render
+		expect(renderCount).toBe(1);
+
+		act(() => {
+			internalStore.setState({
+				trackPlaying: {
+					id: '1',
+					url: 'https://example.com',
+					title: 'Test',
+					artwork: 'https://example.com/art.jpg',
+				},
+			});
+		});
+		// track change should trigger re-render
+		expect(renderCount).toBe(2);
+
+		act(() => {
+			testRenderer!.unmount();
+		});
+	});
+});


### PR DESCRIPTION
## Summary
- streamline `useAudioPro` implementation with a clear default selector
- add typed helper to wrap Zustand store calls

## Testing
- `npx eslint src/useAudioPro.ts`
- `yarn test`


------
https://chatgpt.com/codex/tasks/task_e_68b7a579c1a4832da11aeaf95fe2c332