### PR TITLE
fix(android): add small icon to fallback notification

### DIFF
--- a/android/src/main/java/dev/rnap/reactnativeaudiopro/AudioProPlaybackService.kt
+++ b/android/src/main/java/dev/rnap/reactnativeaudiopro/AudioProPlaybackService.kt
@@ -279,22 +279,22 @@ open class AudioProPlaybackService : MediaLibraryService() {
 				// Notification permission is required but not granted
 				return
 			}
-			val notificationManagerCompat =
-				NotificationManagerCompat.from(this@AudioProPlaybackService)
-			ensureNotificationChannel(notificationManagerCompat)
-			val builder =
-				NotificationCompat.Builder(this@AudioProPlaybackService, CHANNEL_ID)
-					//.setSmallIcon(R.drawable.media3_notification_small_icon)
-					//.setContentTitle(getString(R.string.notification_content_title))
-					//.setStyle(
-					//  NotificationCompat.BigTextStyle().bigText(getString(R.string.notification_content_text))
-					//)
-					.setPriority(NotificationCompat.PRIORITY_DEFAULT)
-					.setAutoCancel(true)
-					.also { builder -> getSessionActivityIntent()?.let { builder.setContentIntent(it) } }
-			notificationManagerCompat.notify(NOTIFICATION_ID, builder.build())
-		}
-	}
+                        val notificationManagerCompat =
+                                NotificationManagerCompat.from(this@AudioProPlaybackService)
+                        ensureNotificationChannel(notificationManagerCompat)
+                        val builder =
+                                NotificationCompat.Builder(this@AudioProPlaybackService, CHANNEL_ID)
+                                        .setSmallIcon(android.R.drawable.ic_dialog_info)
+                                        .setPriority(NotificationCompat.PRIORITY_DEFAULT)
+                                        .setAutoCancel(true)
+                                        .also { builder ->
+                                                getSessionActivityIntent()?.let {
+                                                        builder.setContentIntent(it)
+                                                }
+                                        }
+                        notificationManagerCompat.notify(NOTIFICATION_ID, builder.build())
+                }
+        }
 
 	private fun ensureNotificationChannel(notificationManagerCompat: NotificationManagerCompat) {
 		val channel =


### PR DESCRIPTION
## Summary
- add a default small icon to the fallback notification shown when a foreground service can't start

## Testing
- `yarn test`


------
https://chatgpt.com/codex/tasks/task_e_68b7bc512cf4832d8f51114019ccc852