### PR TITLE
fix: stabilize useAudioPro snapshot

### DIFF
--- a/src/useAudioPro.ts
+++ b/src/useAudioPro.ts
@@ -1,4 +1,4 @@
-import { shallow } from 'zustand/shallow';
+import { useShallow } from 'zustand/shallow';
 
 import { internalStore } from './internalStore';
 
@@ -26,11 +26,10 @@ const selectAll = (state: AudioProStore): UseAudioProReturn => ({
 	error: state.error,
 });
 
-// Typed wrapper around the Zustand hook so we can reuse it below.
-const select = internalStore as unknown as <T>(
-	selector: (state: AudioProStore) => T,
-	equalityFn?: (left: T, right: T) => boolean,
-) => T;
+const select = internalStore as unknown as {
+	<T>(selector: (state: AudioProStore) => T): T;
+	<T>(selector: (state: AudioProStore) => T, equalityFn?: (left: T, right: T) => boolean): T;
+};
 
 /**
  * React hook for accessing the current state of the audio player.
@@ -48,9 +47,11 @@ export function useAudioPro<T>(
 	selector?: (state: AudioProStore) => T,
 	equalityFn?: (left: T, right: T) => boolean,
 ): UseAudioProReturn | T {
+	const selectAllWithShallow = useShallow(selectAll);
+
 	if (selector) {
 		return select(selector, equalityFn);
 	}
 
-	return select(selectAll, shallow);
+	return internalStore(selectAllWithShallow);
 }


### PR DESCRIPTION
## Summary
- replace the shallow equality argument with zustand's `useShallow` helper so the default selector snapshot is cached
- preserve the existing selector overloads by wrapping the store hook in a typed helper

## Testing
- yarn test useAudioPro.selector.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_69095739d77c832da51e1aed3abbb696