### PR TITLE
android: rebuild media browser after service kill

### DIFF
--- a/android/src/main/java/dev/rnap/reactnativeaudiopro/AudioProController.kt
+++ b/android/src/main/java/dev/rnap/reactnativeaudiopro/AudioProController.kt
@@ -33,7 +33,7 @@ object AudioProController {
 	private var engineProgressRunnable: Runnable? = null
 	private var enginePlayerListener: Player.Listener? = null
 	private val engineBrowserConnectionListener =
-		object : MediaController.Listener {
+		object : MediaBrowser.Listener {
 			override fun onDisconnected(controller: MediaController) {
 				log("MediaBrowser disconnected, clearing cached instance")
 				handleBrowserDisconnected(controller)
@@ -89,10 +89,8 @@ object AudioProController {
 		runOnUiThread {
 			// Only clear if we're dealing with the active controller reference
 			if (enginerBrowser == controller) {
-				val currentBrowser = enginerBrowser
 				detachPlayerListener()
 				stopProgressTimer()
-				currentBrowser?.removeListener(engineBrowserConnectionListener)
 				if (::engineBrowserFuture.isInitialized) {
 					MediaBrowser.releaseFuture(engineBrowserFuture)
 				}
@@ -117,7 +115,6 @@ object AudioProController {
 			}
 			if (enginerBrowser != null) {
 				detachPlayerListener()
-				enginerBrowser?.removeListener(engineBrowserConnectionListener)
 				enginerBrowser = null
 			}
 			if (hasConnectedBrowser()) {
@@ -136,9 +133,9 @@ object AudioProController {
 				)
 			engineBrowserFuture =
 				MediaBrowser.Builder(context, token)
+					.setListener(engineBrowserConnectionListener)
 					.buildAsync()
 			enginerBrowser = engineBrowserFuture.await()
-			enginerBrowser?.addListener(engineBrowserConnectionListener)
 			attachPlayerListener()
 			log("MediaBrowser is ready")
 		} finally {
@@ -487,7 +484,6 @@ object AudioProController {
 			if (::engineBrowserFuture.isInitialized) {
 				MediaBrowser.releaseFuture(engineBrowserFuture)
 			}
-			enginerBrowser?.removeListener(engineBrowserConnectionListener)
 			enginerBrowser = null
 			engineBrowserConnecting = false
 		}

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -1,5 +1,5 @@
 PODS:
-  - AudioPro (10.1.1):
+  - AudioPro (10.1.2):
     - DoubleConversion
     - glog
     - hermes-engine
@@ -1808,7 +1808,7 @@ EXTERNAL SOURCES:
     :path: "../node_modules/react-native/ReactCommon/yoga"
 
 SPEC CHECKSUMS:
-  AudioPro: ca6758514549ae76f7bcc95fff903a96c1c85063
+  AudioPro: a8df0c5586b922884c9bd4e9c5409111d7a18260
   boost: 7e761d76ca2ce687f7cc98e698152abd03a18f90
   DoubleConversion: cb417026b2400c8f53ae97020b2be961b59470cb
   fast_float: 06eeec4fe712a76acc9376682e4808b05ce978b6


### PR DESCRIPTION
Restores the Android playback session after the service is swiped away by rebuilding the MediaBrowser and clearing stale controllers.

Testing: ./gradlew lint (fails: missing com.facebook.react:react-android in workspace).