### PR TITLE
fix(ios): convert skip interval to seconds for lock screen controls

### DIFF
--- a/ios/AudioPro.swift
+++ b/ios/AudioPro.swift
@@ -1209,8 +1209,9 @@ class AudioPro: RCTEventEmitter {
 			return .success
 		}
 
-		commandCenter.skipForwardCommand.preferredIntervals = [NSNumber(value: settingSkipIntervalMs)]
-		commandCenter.skipBackwardCommand.preferredIntervals = [NSNumber(value: settingSkipIntervalMs)]
+		let skipIntervalSeconds = settingSkipIntervalMs / 1000.0
+		commandCenter.skipForwardCommand.preferredIntervals = [NSNumber(value: skipIntervalSeconds)]
+		commandCenter.skipBackwardCommand.preferredIntervals = [NSNumber(value: skipIntervalSeconds)]
 
 		isRemoteCommandCenterSetup = true
 	}


### PR DESCRIPTION
iOS expects `preferredIntervals` to be in seconds, not milliseconds: https://developer.apple.com/documentation/mediaplayer/mpskipintervalcommand/preferredintervals

this is causing the skip back/forward lock screen controls to render with -/+ symbols instead of the skip interval

thank you for this great library, it's been a pleasure to use so far!