### PR TITLE
fix(ios): preserve playback speed after pause/resume and audio interruptions

### DIFF
--- a/ios/AudioPro.swift
+++ b/ios/AudioPro.swift
@@ -162,13 +162,19 @@ class AudioPro: RCTEventEmitter {
 
 					// Resume playback
 					player?.play()
+
+					// Restore playback speed — AVPlayer.play() resets rate to 1.0
+					if currentPlaybackSpeed != 1.0 {
+						player?.rate = currentPlaybackSpeed
+					}
+
 					startProgressTimer()
 
 					// Emit PLAYING state
 					sendPlayingStateEvent()
 
 					// Update now playing info
-					updateNowPlayingInfo(time: player?.currentTime().seconds ?? 0, rate: 1.0)
+					updateNowPlayingInfo(time: player?.currentTime().seconds ?? 0, rate: Float(currentPlaybackSpeed))
 				} catch {
 					log("Failed to reactivate audio session: \(error.localizedDescription)")
 					emitPlaybackError("Failed to resume after interruption: \(error.localizedDescription)")
@@ -549,8 +555,13 @@ class AudioPro: RCTEventEmitter {
 
 		player?.play()
 
+		// Restore playback speed — AVPlayer.play() resets rate to 1.0
+		if currentPlaybackSpeed != 1.0 {
+			player?.rate = currentPlaybackSpeed
+		}
+
 		// Ensure lock screen controls are properly updated
-		updateNowPlayingInfo(time: player?.currentTime().seconds ?? 0, rate: 1.0)
+		updateNowPlayingInfo(time: player?.currentTime().seconds ?? 0, rate: Float(currentPlaybackSpeed))
 
 		// Note: We don't need to call sendPlayingStateEvent() here because
 		// the rate change will trigger observeValue which now calls sendPlayingStateEvent()


### PR DESCRIPTION
## Summary
  - Fix playback speed resetting to 1.0x on resume — `AVPlayer.play()` implicitly sets `rate = 1.0`, discarding the stored `currentPlaybackSpeed`
  - Fix the same issue in the audio interruption handler (e.g., phone call, Siri), where speed was also lost on resume
  - Update `updateNowPlayingInfo` calls to use `currentPlaybackSpeed` instead of hardcoded `1.0` so lock screen controls reflect the correct rate

  ## Root Cause
  `AVPlayer.play()` is equivalent to setting `rate = 1.0`. Both `resume()` and the interruption-ended handler called `player?.play()` without restoring the custom
  rate afterward.

  Android is unaffected — Media3's `play()` sets `playWhenReady = true` without changing `PlaybackParameters`.

  ## Test plan
  - [x] Play audio, set speed to 1.5x or 2x
  - [x] Pause, then resume — speed should remain at the set value
  - [x] While playing at non-1.0 speed, trigger an audio interruption (e.g., Siri) and verify speed is preserved after interruption ends
  - [x] Verify lock screen now-playing info shows the correct playback rate