### PR TITLE
fix(ios): prevent UI freeze from sync artwork fetch and duration access

### DIFF
--- a/ios/AudioPro.swift
+++ b/ios/AudioPro.swift
@@ -324,14 +324,15 @@ class AudioPro: RCTEventEmitter {
 		guard
 			let urlString = track["url"] as? String,
 			let url = URL(string: urlString),
-			let title = track["title"] as? String,
-			let artworkUrlString = track["artwork"] as? String,
-			let artworkUrl = URL(string: artworkUrlString)
+			let title = track["title"] as? String
 		else {
 			onError("Invalid track data")
 			cleanup()
 			return
 		}
+
+		let artworkUrlString = track["artwork"] as? String ?? ""
+		let artworkUrl: URL? = artworkUrlString.isEmpty ? nil : URL(string: artworkUrlString)
 
 		do {
 			let contentType = options["contentType"] as? String ?? "MUSIC"

--- a/ios/AudioPro.swift
+++ b/ios/AudioPro.swift
@@ -416,7 +416,7 @@ class AudioPro: RCTEventEmitter {
 		nowPlayingInfo = MPNowPlayingInfoCenter.default().nowPlayingInfo ?? [:]
 		nowPlayingInfo[MPNowPlayingInfoPropertyElapsedPlaybackTime] = 0
 		nowPlayingInfo[MPNowPlayingInfoPropertyPlaybackRate] = 1.0
-		nowPlayingInfo[MPMediaItemPropertyPlaybackDuration] = item.asset.duration.seconds
+		// Duration is set asynchronously via progress events once the player item loads
 		MPNowPlayingInfoCenter.default().nowPlayingInfo = nowPlayingInfo
 
 		// Add notification observer for track completion to the new item

--- a/src/audioPro.ts
+++ b/src/audioPro.ts
@@ -116,7 +116,7 @@ export const AudioPro = {
 
 		// Validate URL schemes for track and artwork
 		validateFilePath(resolvedTrack.url);
-		validateFilePath(resolvedTrack.artwork);
+		if (resolvedTrack.artwork) validateFilePath(resolvedTrack.artwork);
 
 		if (!validateTrack(resolvedTrack)) {
 			const errorMessage = '[react-native-audio-pro]: Invalid track provided to play().';

--- a/src/types.ts
+++ b/src/types.ts
@@ -16,7 +16,7 @@ export type AudioProTrack = {
 	id: string;
 	url: string;
 	title: string;
-	artwork: AudioProArtwork;
+	artwork?: AudioProArtwork;
 	album?: string;
 	artist?: string;
 	[key: string]: unknown; // custom properties

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -11,8 +11,10 @@ import type { AudioProTrack } from './types';
  * @param path - The path or URL to validate.
  */
 export function validateFilePath(path: string) {
+	if (!path || !path.trim()) return;
+
 	const supportedSchemes = ['http://', 'https://', 'file://'];
-	if (!supportedSchemes.some((scheme) => path && path.startsWith(scheme))) {
+	if (!supportedSchemes.some((scheme) => path.startsWith(scheme))) {
 		console.error(
 			`[react-native-audio-pro] Invalid file path detected: ${path}. ` +
 				`Only http://, https://, and file:// schemes are recognized.`,
@@ -95,9 +97,14 @@ export function validateTrack(track: AudioProTrack): boolean {
 		return false;
 	}
 
-	// 5. Artwork URL must be a non-empty string and valid
-	if (typeof track.artwork !== 'string' || !track.artwork.trim() || !isValidUrl(track.artwork)) {
-		logDebug('Track validation failed: invalid or missing track.artwork');
+	// 5. Artwork URL is optional - if provided, must be valid
+	if (
+		track.artwork &&
+		typeof track.artwork === 'string' &&
+		track.artwork.trim() &&
+		!isValidUrl(track.artwork)
+	) {
+		logDebug('Track validation failed: invalid track.artwork');
 		return false;
 	}
 


### PR DESCRIPTION
Fixes #147

## Summary

Fixes two iOS blocking issues that cause the app to freeze on slow/bad networks:

1. **Artwork fetch blocked threads** - `Data(contentsOf:)` and semaphore-based URLSession calls blocked GCD threads while fetching artwork for the lock screen. On failure, `onError()` tore down the entire player. Now uses fully async `URLSession` with a 10s timeout and emits a soft `PLAYBACK_ERROR` on failure.

2. **`item.asset.duration.seconds` blocked on HLS** - Accessing `AVAsset.duration` synchronously forces metadata loading, which requires fetching and parsing the m3u8 playlist. Removed this synchronous access; duration is already set via progress events once the player item is loaded.

3. **Artwork is now optional** - Empty or missing artwork no longer causes validation failures or player errors. The `AudioProTrack.artwork` field is now optional in the TypeScript type and all JS/native validation.

## Reproduction

1. Use Network Link Conditioner set to "Very Bad Network"
2. Play any HLS track with a remote artwork URL
3. Before fix: entire app freezes for 5-30 seconds
4. After fix: audio plays immediately, artwork loads asynchronously when available

## Changes

- `src/types.ts` - Make `artwork` optional in `AudioProTrack`
- `src/utils.ts` - Allow empty artwork in validation
- `ios/AudioPro.swift` - Three changes:
  - Extract artwork from required `guard` statement
  - Replace sync artwork fetch with async `URLSession` + 10s timeout
  - Remove sync `item.asset.duration.seconds` access

## Test plan

- [ ] Play track with artwork - artwork appears on lock screen
- [ ] Play track without artwork - no crash, audio plays
- [ ] Play on very bad network - no freeze
- [ ] Rapid track switching on bad network - no freeze
- [ ] Lock screen controls work correctly
- [ ] Duration shows correctly on lock screen after load