### PR TITLE
feat: customizable Android notification channel name

### DIFF
--- a/android/src/main/java/dev/rnap/reactnativeaudiopro/AudioProPlaybackService.kt
+++ b/android/src/main/java/dev/rnap/reactnativeaudiopro/AudioProPlaybackService.kt
@@ -294,7 +294,7 @@ open class AudioProPlaybackService : MediaLibraryService() {
 		val channel =
 			NotificationChannel(
 				CHANNEL_ID,
-				"audio_pro_notification_channel",
+				getString(R.string.audiopro_channel_name),
 				NotificationManager.IMPORTANCE_DEFAULT,
 			)
 		notificationManagerCompat.createNotificationChannel(channel)


### PR DESCRIPTION
The Android notification channel was hardcoded to "audio_pro_notification_channel" so updated the code to use the existing "audiopro_channel_name" defined in strings.xml so that it has a better default and can be customized by consumers.